### PR TITLE
Add `test_file_regex` argument.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,10 @@ inputs:
     description: Name to install the package as
     required: false
     default: ${{ github.event.repository.name }}  # github.repository has full name
+  test_file_regex:
+    description: POSIX egrep pattern passed to `find -regex` to choose files to test
+    required: false
+    default: '.*/syntax_test.*'
 
 outputs: {}
 
@@ -58,3 +62,4 @@ runs:
         INPUT_DEFAULT_TESTS: ${{ inputs.default_tests }}
         INPUT_PACKAGE_ROOT: ${{ inputs.package_root }}
         INPUT_PACKAGE_NAME: ${{ inputs.package_name }}
+        INPUT_TEST_FILE_REGEX: ${{ inputs.test_file_regex }}

--- a/syntax-tests.sh
+++ b/syntax-tests.sh
@@ -43,7 +43,7 @@ fetch_default_packages() {
     wget --content-disposition "https://github.com/sublimehq/Packages/archive/$INPUT_DEFAULT_PACKAGES.tar.gz"
     tar xf Packages-*.tar.gz
     if [[ $INPUT_DEFAULT_TESTS != true ]]; then
-        find Packages-*/ -type f -name 'syntax_test*' -exec rm -v '{}' \;
+        find Packages-*/ -type f -regextype posix-egrep -regex '$INPUT_TEST_FILE_REGEX' -exec rm -v '{}' \;
     fi
     find Packages-*/ \
         -type d \


### PR DESCRIPTION
Addresses https://github.com/SublimeText/syntax-test-action/issues/14. I chose regex because it allows users to easily include multiple directories if desired, e.g.:

```
./(tests1|tests2)/syntax_test.*
```

I have tested the pattern on `ubuntu:latest`, but I don't know how to test the GitHub action itself.