### PR TITLE
Replace obsolete libgl1-mesa-glx

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -47,7 +47,8 @@ runs:
           echo "::group::Installing dependencies"
           sudo apt-get update && sudo apt-get install -y \
             libcairo2 \
-            libgl1-mesa-glx \
+            libgl1 \
+            libglx-mesa0 \
             libglib2.0-0 \
             libglu1-mesa \
             libgtk-3-0 \


### PR DESCRIPTION
Fixes #17

This PR replaces obsolete `libgl1-mesa-glx` by `libgl1` and `libglx-mesa0` to maintain compatibility with Ubuntu 24+

source: https://askubuntu.com/questions/1517352/issues-installing-libgl1-mesa-glx