### PR TITLE
Fetch latest "stable" build from update check endpoint

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,32 +3,32 @@ name: Tests
 on: [push, pull_request]
 
 jobs:
-  no_defpkg:
-    name: Without default packages
+  no_defpkg_stable:
+    name: Without default packages, latest stable
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: ./
         with:
-          build: 4189
+          build: stable
           package_root: test/no_defpkg
 
   # TODO indentation tests
   # TODO reference & definition tests
 
-  defpkg:
+  defpkg_stable:
     name: With default packages, latest stable
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: ./
         with:
-          build: 4189
-          default_packages: master
+          build: stable
+          default_packages: binary
           package_root: test/defpkg
 
   no_defpkg_old_build:
-    name: Without default packages, old build
+    name: Without default packages, build 4073
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -47,8 +47,8 @@ jobs:
           build: latest
           package_root: test/no_defpkg
 
-  third-party:
-    name: Third-party
+  third-party_stable:
+    name: Third-party, latest stable
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo (primary package)
@@ -61,19 +61,19 @@ jobs:
           path: third-party/INI
       - uses: ./
         with:
-          build: 4189  # stable
+          build: stable
           package_root: test/third-party
           additional_packages: third-party/INI
 
-  dummy_syntax:
-    name: Dummy Syntax
+  dummy_syntax_stable:
+    name: Dummy Syntax, latest stable
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo (primary package)
         uses: actions/checkout@v4
       - uses: ./
         with:
-          build: 4189  # stable
+          build: stable
           package_root: test/dummy-syntax
           dummy_syntaxes: text.dummy
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,16 +37,6 @@ jobs:
           build: 4073
           package_root: test/no_defpkg
 
-  no_defpkg_old_runtime:
-    name: Without default packages, latest build, ubuntu-20.04
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./
-        with:
-          build: latest
-          package_root: test/no_defpkg
-
   third-party_stable:
     name: Third-party, latest stable
     runs-on: ubuntu-latest
@@ -78,7 +68,7 @@ jobs:
           dummy_syntaxes: text.dummy
 
   st3:
-    name: ST3 build
+    name: Without default packages, ST3
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -87,6 +77,16 @@ jobs:
           build: 3210
           default_packages: v3189
           package_root: test/st3
+
+  st3_no_defpkg_old_runtime:
+    name: Without default packages, ST3, ubuntu-20.04
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./
+        with:
+          build: 3210
+          package_root: test/no_defpkg
 
   # This is expected to error and used to test the error wrapper
   st3_error:

--- a/README.md
+++ b/README.md
@@ -134,15 +134,15 @@ jobs:
 
 ## Inputs
 
-| Name                     | Default         | Description                                                                                |
-| :----------------------- | :-------------- | :----------------------------------------------------------------------------------------- |
-| **build**                | `"latest"`      | ST build that should be installed as an integer. Not all builds are available.             |
+| Name                     | Default         | Description |
+| :----------------------- | :-------------- | :---------- |
+| **build**                | `"latest"`      | ST build that should be installed as an integer. Not all builds are available. |
 | **default\_packages**    | `false`         | Install the [default packages][] and which version (accepts any git ref, e.g. `"master"`). |
-| **default\_tests**       | `false`         | Whether to keep the tests of the default packages.                                         |
+| **default\_tests**       | `false`         | Whether to keep the tests of the default packages. |
 | **additional\_packages** | `""`            | Comma-separated list of paths to additionally checked out packages to install (e.g.: `LESS,third-party/Sass`). Uses the folders' base names as the package names to install as. |
-| **additional\_tests**    | `false`         | Whether to keep the tests of the additional packages.                                      |
-| **package\_root**        | `"."`           | Path to the package root that is linked to the testing Packages folder.                    |
-| **package\_name**        | Repository name | Name to install the package as.                                                            |
+| **additional\_tests**    | `false`         | Whether to keep the tests of the additional packages. |
+| **package\_root**        | `"."`           | Path to the package root that is linked to the testing Packages folder. |
+| **package\_name**        | Repository name | Name to install the package as. |
 | **dummy\_syntaxes**      | `""`            | Comma-separated list of base scopes to create empty syntaxes for, e.g. `source.postcss,source.stylus`. |
 
 [default packages]: https://github.com/sublimehq/Packages/
@@ -152,9 +152,16 @@ jobs:
 
 ### v2
 
+### v2.4 (2025-01-12)
+
+- Added `dummy_syntaxes` input that creates empty syntax files
+  to satisfy external `embed`s that would otherwise result in CI failures.
+  (@FichteFoll, #13, #20)
+
 ### v2.3 (2025-01-11)
 
-- Fix dependencies for `ubuntu-24.04` runner. (@deathaxe, #17, #18)
+- Fix dependencies for `ubuntu-24.04` runner.
+  (@deathaxe, #17, #18)
 
 ### v2.2 (2023-01-08)
 
@@ -165,16 +172,19 @@ jobs:
 ### v2.1 (2021-06-07)
 
 - Treat `'latest'` as an ST4 build now that the upstream URL has been updated.
+  (@FichteFoll)
 - Group dependency installation, if necessary.
+  (@FichteFoll)
 
 ### v2.0 (2020-08-28)
 
-- Updated to new upstream download paths.
-- Does not fetch dependencies anymore for 4077+.
-- Changed from docker to composite action.
+- Updated to new upstream download paths. (@FichteFoll)
+- Does not fetch dependencies anymore for 4077+. (@FichteFoll, #2)
+- Changed from docker to composite action. (@FichteFoll)
 
 ### v1 (2020-06-07)
 
 Initial working version
 supporting ST3 and ST4 builds
 as well as fetching the default packages.
+(@FichteFoll)

--- a/README.md
+++ b/README.md
@@ -34,8 +34,10 @@ jobs:
         include:
           - build: latest  # This is the default
             # packages: master  # If you depend on a default syntax definition
+          - build: stable  # Fetches the binary for the latest stable build
+            # packages: binary  # Use respective tag for the selected binary build.
           - build: 3210  # Latest known ST3 build with a test binary
-            # packages: v3189   # Latest ST3 tag on the Packages repo
+            # packages: v3189  # Latest ST3 tag on the Packages repo
     steps:
       - uses: actions/checkout@v4
       - uses: SublimeText/syntax-test-action@v2
@@ -136,8 +138,8 @@ jobs:
 
 | Name                     | Default         | Description |
 | :----------------------- | :-------------- | :---------- |
-| **build**                | `"latest"`      | ST build that should be installed as an integer. Not all builds are available. |
-| **default\_packages**    | `false`         | Install the [default packages][] and which version (accepts any git ref, e.g. `"master"`). |
+| **build**                | `"latest"`      | ST build that should be installed as an integer. `"latest"` is for the dev channel, `"stable"` for the stable channel. Not all builds are available. |
+| **default\_packages**    | `"false"`       | Install the [default packages][] and which version. Accepts any git ref, e.g. `"master"`, or `"binary"` for the tag of the respective binary. Note that the corresponding tag may not always exist. |
 | **default\_tests**       | `false`         | Whether to keep the tests of the default packages. |
 | **additional\_packages** | `""`            | Comma-separated list of paths to additionally checked out packages to install (e.g.: `LESS,third-party/Sass`). Uses the folders' base names as the package names to install as. |
 | **additional\_tests**    | `false`         | Whether to keep the tests of the additional packages. |

--- a/syntax-tests.sh
+++ b/syntax-tests.sh
@@ -64,9 +64,9 @@ fetch_default_packages() {
         return
     fi
     if [[ $INPUT_DEFAULT_PACKAGES == binary ]]; then
-        echo "::debug::Using tag of binary version: $binary_build"
-        # Note: Tag may not always exist yet as they seem to be created manually.
-        ref="v$binary_build"
+        tag_build="$(get_closest_tag "$binary_build")"
+        ref="v$tag_build"
+        echo "Using closest tag to binary version: $ref"
     fi
 
     echo "::group::Fetching default packages (ref: $ref, tests: $INPUT_DEFAULT_TESTS)"
@@ -84,6 +84,16 @@ fetch_default_packages() {
         -exec mv -vt "$packages/" '{}' +
     popd
     echo '::endgroup::'
+}
+
+get_closest_tag() {
+    local base="$1"
+    git ls-remote --tags https://github.com/sublimehq/Packages.git "refs/tags/v????" \
+        | cut -f2 \
+        | cut -d'v' -f2 \
+        | awk "{ if (\$1 <= $base) { print \$1 } }" \
+        | sort -r \
+        | head -n1
 }
 
 link_package() {


### PR DESCRIPTION
Also support new "binary" value for packages ref to automatically use the same build tag as for the binary.

Addresses the second point of #6 that should arguably have been its own issue.