### PR TITLE
Run tests on a weekly schedule

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,11 @@
 name: Tests
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "* 0 * * SAT"
+  workflow_dispatch:
 
 jobs:
   no_defpkg:


### PR DESCRIPTION
Also allow manual workflow dispatches.

Pull requests and pushes still create each job twice for a push to an open pull request within the same repo, but fixing that is non-trivial and I frankly don't care enough. I still want the pipeline runs for non-default branches for testing without a PR.

Closes #6